### PR TITLE
Do not expose Mongo and ES ports to the public

### DIFF
--- a/graylog/docker-compose.yml
+++ b/graylog/docker-compose.yml
@@ -90,8 +90,6 @@ services:
     image: mongo-express
     stdin_open: true
     tty: true
-    ports:
-      - 8081:8081/tcp
     labels:
       io.rancher.container.pull_image: always
 
@@ -99,8 +97,6 @@ services:
     image: elasticsearch:2-alpine
     stdin_open: true
     tty: true
-    ports:
-      - 9200:9200/tcp
     command:
       - elasticsearch
       - -Des.cluster.name=graylog


### PR DESCRIPTION
Containers are still reachable inside Rancher network without exposing the ports.

Fixes #2 and #4